### PR TITLE
Fix: Compatibility with other themes than light theme

### DIFF
--- a/book/theme/tabs.css
+++ b/book/theme/tabs.css
@@ -3,7 +3,7 @@
 }
 
 .mdbook-tab {
-    background-color: #f6f7f6;
+    background-color: var(--table-alternate-bg);
     padding: 0.5rem 1rem;
     cursor: pointer;
     border: none;


### PR DESCRIPTION
Hello,

Currently the tabs are shown correctly only with the light theme.

But with the other themes we get something like that:
![tabs-dark-theme](https://github.com/user-attachments/assets/de6fce67-30a5-4086-8f68-c8490cbeaa08)

To fix that instead of using a fixed color, we can use a theme color.

Thank you very much for this project by the way.
